### PR TITLE
Обновлен скрипт сборщика на питоне 

### DIFF
--- a/build.py
+++ b/build.py
@@ -84,7 +84,7 @@ def build_kernel(warnings=False):
 
 def build_apps():
     os.chdir("apps/")
-    os.system("python build.py")
+    os.system("python3 build.py")
 
     shutil.rmtree("../initrd/apps", ignore_errors=True)
     shutil.copytree("../bin/apps", "../initrd/apps")


### PR DESCRIPTION
Из-за того что не укаждого стоит по умолчанию 3й питон, на чистой системе, нужно принудительно его прописать.

Изменил на 86 строке:
Было: `os.system("python build.py")`
Стало: `os.system("python3 build.py")`