### PR TITLE
CPUInfo + 2 новых фнк для string.c

### DIFF
--- a/kernel/include/kernel.h
+++ b/kernel/include/kernel.h
@@ -33,6 +33,7 @@
 #include <io/vgafnt.h>
 #include <io/ports.h>
 
+#include <sys/cpuinfo.h>
 #include <sys/system.h>
 #include <sys/gdt.h>
 #include <sys/idt.h>

--- a/kernel/include/libk/string.h
+++ b/kernel/include/libk/string.h
@@ -21,3 +21,5 @@ void* memcpy(void*, const void*, size_t);
 void substr(char* dest, char* source, int from, int length);
 char *strchr(const char *_s, int _c);
 char *strstr(const char *_haystack, const char *_needle);
+void strtolower(char* as);
+void strtoupper(char* as);

--- a/kernel/include/mem/pmm.h
+++ b/kernel/include/mem/pmm.h
@@ -4,3 +4,7 @@ void pmm_init(struct multiboot_info *mboot_info);
 physical_addres_t pmm_alloc_block();
 void pmm_free_block(physical_addres_t addr);
 void update_phys_memory_bitmap_addres(physical_addres_t addr);
+
+uint64_t getInstalledRam();
+uint64_t getAvailableRam();
+uint64_t getUsedRam();

--- a/kernel/include/sys/cpuinfo.h
+++ b/kernel/include/sys/cpuinfo.h
@@ -1,0 +1,11 @@
+#pragma once
+#define cpuid(in, a, b, c, d) __asm__("cpuid": "=a" (a), \
+                                               "=b" (b), \
+                                               "=c" (c), \
+                                               "=d" (d) : \
+                                               "a" (in));
+int do_intel(bool silent);
+int do_amd(bool silent);
+char* printregs(int eax, int ebx, int ecx, int edx);
+int detect_cpu(bool silent);
+char* getNameBrand();

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -65,16 +65,15 @@ void kernel(uint32_t magic_number, struct multiboot_info *mboot_info) {
     unit_test(RTL8139_init());              // Тестируем драйвер RTL8139
 
     vfs_mount_list();                       // Выводим список корня VFS
-
+    detect_cpu(1);
     // while(1){
     //     asm volatile("hlt");
     // }
     //qemu_log("task: %d", create_task());
 
-    //init_task_manager();
+    init_task_manager();
     //create_STFS(0);
-    //tui();
-    tty_printf("\n%d\n%s\n", 101/10, format_string("Hello! %d, %x, %c, %s", 1, 0x90, 'H', "Hi!"));
+    tui();
     shell();                                // Активация терминала
 
 

--- a/kernel/src/drivers/pci.c
+++ b/kernel/src/drivers/pci.c
@@ -67,11 +67,12 @@ void checkAllBuses() {
     for (uint16_t bus = 0; bus < 256; bus++) {
         for (uint8_t device = 0; device < 32; device++) {
             for (uint8_t function = 1; function < 8; function++) {
-                if (getDeviceID(bus, device, function) != 0 & getDeviceID(bus, device, function) != 65535 ){    
+				uint16_t id = getDeviceID(bus, device, function);
+                if (id != 0 & id != 65535){
                     tty_printf("\t%d->", bus);
                     qemu_log("%d->", bus);
 
-					switch (getDeviceID(bus, device, function)) {
+					switch (id) {
 						case 0x7010:
 							tty_printf("82371SB PIIX3 IDE [Natoma/Triton II] ");
 							qemu_log("82371SB PIIX3 IDE [Natoma/Triton II] ");
@@ -144,6 +145,18 @@ void checkAllBuses() {
 							tty_printf("RTL8139 Ethernet ");
 							qemu_log("RTL8139 Ethernet ");
 							break;
+						case 0xBEEF:
+							tty_printf("VirtualBox Virtual Driver");
+							qemu_log("VirtualBox Virtual Driver");
+							break;
+						case 0x1111:
+							tty_printf("QEMU Virtual Driver");
+							qemu_log("QEMU Virtual Driver");
+							break;
+						case 0xCAFE:
+							tty_printf("VirtualBox Guest Additions Driver");
+							qemu_log("VirtualBox Guest Additions Driver");
+							break;
 						default:
 							tty_printf("device %x ", getDeviceID(bus, device, function));
 							qemu_log("device %x ", getDeviceID(bus, device, function));
@@ -165,6 +178,14 @@ void checkAllBuses() {
 						case 0x0B05:
 							tty_printf("ASUSTek Computer, Inc.");
 							qemu_log("ASUSTek Computer, Inc.");
+							break;
+						case 0x80EE:
+							tty_printf("VirtualBox internal");
+							qemu_log("VirtualBox internal");
+							break;
+						case 0x1234:
+							tty_printf("QEMU internal");
+							qemu_log("QEMU internal");
 							break;
 						default:
 							tty_printf("vendor %x", getVendorID(bus, device, function));

--- a/kernel/src/io/shell.c
+++ b/kernel/src/io/shell.c
@@ -40,6 +40,8 @@ void shell() {
             shutdown();
         } else if (strcmp(cmd, "cls") == 0) {
             clean_screen();
+        } else if (strcmp(cmd, "cpuinfo") == 0) {
+            detect_cpu(0);
         } else if (strcmp(cmd, "help") == 0) {
             tty_printf("Commands:\n" \
                         "\t\t->help                |get list of commands\n" \
@@ -51,6 +53,7 @@ void shell() {
                         "\t\t->ls                  |list of files\n" \
                         "\t\t->sysinfo             |information about system\n" \
                         "\t\t->pcilist             |list of pci devices\n" \
+                        "\t\t->cpuinfo             |info cpu\n" \
                         "\t\t->reboot              |reboot device\n" \
                         "\t\t->shutdown            |shutdown device\n" \
                         "\n" 

--- a/kernel/src/io/tui.c
+++ b/kernel/src/io/tui.c
@@ -420,7 +420,9 @@ bool tui(){
         return false;
     }
     tty_printf("TUI Kerner Test...\n");
-    sleep(30);
+
+    sleep(300);
+    //return false;
     int32_t i = 0;
 
     char* OSNAME = "SynapseOS v0.2.12 (Dev)";
@@ -454,7 +456,9 @@ bool tui(){
             setPosX(16);
             setPosY(48);
             char infoCPU[512];
-            substr(infoCPU, "CPU: TEST CPU", 0, (maxStrLine/2)-2);
+            strcat(infoCPU,"CPU: ");
+            strcat(infoCPU,getNameBrand());
+            substr(infoCPU, infoCPU, 0, (maxStrLine/2)-2);
             tty_puts_color(infoCPU,txColor, bgColor);
 
             setPosX(16);
@@ -478,8 +482,8 @@ bool tui(){
 
             setPosX(16);
             setPosY(128);
-            tty_puts_color("Error in TUI module. You will be returned to the console in 10 seconds.",txColor, bgColor);
-            sleep(1000);
+            tty_puts_color("Error in TUI module. You will be returned to the console in 5 seconds.",txColor, bgColor);
+            sleep(500);
             break;
 
         }

--- a/kernel/src/libk/string.c
+++ b/kernel/src/libk/string.c
@@ -204,3 +204,22 @@ char *strstr(const char *_haystack, const char *_needle)
 	return NULL;
 }
 
+
+void strtolower(char* as)
+{
+	while(*as != 0)
+	{
+		if(*as >= 'A' && *as <= 'Z')
+			*as += ('a' - 'A');
+		as++;
+	}
+}
+void strtoupper(char* as)
+{
+	while(*as != 0)
+	{
+		if(*as >= 'a' && *as <= 'z')
+			*as -= ('a' - 'A');
+		as++;
+	}
+}

--- a/kernel/src/mem/pmm.c
+++ b/kernel/src/mem/pmm.c
@@ -36,6 +36,18 @@ inline static bool bitmap_test(int32_t bit) {
     return phys_memory_bitmap[bit / 32] & (1 << (bit % 32));
 }
 
+uint64_t getInstalledRam(){
+    return phys_installed_memory_size;
+}
+
+uint64_t getAvailableRam(){
+    return phys_available_memory_size;
+}
+
+uint64_t getUsedRam(){
+    return phys_installed_memory_size-phys_available_memory_size;
+}
+
 
 void pmm_parse_memory_map(multiboot_memory_map_entry *mmap_addr, uint32_t length) {
     multiboot_memory_map_entry *mentry = 0;	

--- a/kernel/src/sys/cpuinfo.c
+++ b/kernel/src/sys/cpuinfo.c
@@ -1,0 +1,377 @@
+#include <kernel.h>
+char brandAllName[128] = "";
+int detect_cpu(bool silent) {
+    brandAllName[128] = "";
+    unsigned long ebx, unused;
+    cpuid(0, unused, ebx, unused, unused);
+    switch (ebx) {
+    case 0x756e6547: /* Intel Magic Code */
+        //strcat(brandAllName,"Intel ");
+        do_intel(silent);
+        break;
+    case 0x68747541: /* AMD Magic Code */
+        //strcat(brandAllName,"AMD ");
+        do_amd(silent);
+        break;
+    default:
+        strcat(brandAllName,"Unknown x86");
+        //tty_printf("Unknown x86 CPU Detected\n");
+        break;
+    }
+    if (silent == 1){
+        tty_printf("[CPU] Detect: %s\n",brandAllName);
+    }
+    return 0;
+}
+
+char* getNameBrand(){
+    return brandAllName;
+}
+
+/* Intel Specific brand list */
+char *Intel[] = {
+    "Brand ID Not Supported.",
+    "Intel(R) Celeron(R) processor",
+    "Intel(R) Pentium(R) III processor",
+    "Intel(R) Pentium(R) III Xeon(R) processor",
+    "Intel(R) Pentium(R) III processor",
+    "Reserved",
+    "Mobile Intel(R) Pentium(R) III processor-M",
+    "Mobile Intel(R) Celeron(R) processor",
+    "Intel(R) Pentium(R) 4 processor",
+    "Intel(R) Pentium(R) 4 processor",
+    "Intel(R) Celeron(R) processor",
+    "Intel(R) Xeon(R) Processor",
+    "Intel(R) Xeon(R) processor MP",
+    "Reserved",
+    "Mobile Intel(R) Pentium(R) 4 processor-M",
+    "Mobile Intel(R) Pentium(R) Celeron(R) processor",
+    "Reserved",
+    "Mobile Genuine Intel(R) processor",
+    "Intel(R) Celeron(R) M processor",
+    "Mobile Intel(R) Celeron(R) processor",
+    "Intel(R) Celeron(R) processor",
+    "Mobile Geniune Intel(R) processor",
+    "Intel(R) Pentium(R) M processor",
+    "Mobile Intel(R) Celeron(R) processor"
+};
+
+/* This table is for those brand strings that have two values depending on the processor signature. It should have the same number of entries as the above table. */
+char *Intel_Other[] = {
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Intel(R) Celeron(R) processor",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Intel(R) Xeon(R) processor MP",
+    "Reserved",
+    "Reserved",
+    "Intel(R) Xeon(R) processor",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved"
+};
+
+/* Intel-specific information */
+int do_intel(bool silent) {
+    if (silent == 0){
+        tty_printf("Detected Intel CPU.\nIntel-specific features:\n");
+    }
+    unsigned long eax, ebx, ecx, edx, max_eax, signature, unused;
+    int model, family, type, brand, stepping, reserved;
+    int extended_family = -1;
+    cpuid(1, eax, ebx, unused, unused);
+    model = (eax >> 4) & 0xf;
+    family = (eax >> 8) & 0xf;
+    type = (eax >> 12) & 0x3;
+    brand = ebx & 0xff;
+    stepping = eax & 0xf;
+    reserved = eax >> 14;
+    signature = eax;
+    if (silent == 0){
+        tty_printf("Type %d - ", type);
+        switch (type) {
+        case 0:
+            tty_printf("Original OEM");
+            break;
+        case 1:
+            tty_printf("Overdrive");
+            break;
+        case 2:
+            tty_printf("Dual-capable");
+            break;
+        case 3:
+            tty_printf("Reserved");
+            break;
+        }
+
+        tty_printf("\n");
+
+        tty_printf("Family %d - ", family);
+        switch (family) {
+        case 3:
+            tty_printf("i386");
+            break;
+        case 4:
+            tty_printf("i486");
+            break;
+        case 5:
+            tty_printf("Pentium");
+            break;
+        case 6:
+            tty_printf("Pentium Pro");
+            break;
+        case 15:
+            tty_printf("Pentium 4");
+        }
+
+        tty_printf("\n");
+
+        if (family == 15) {
+            extended_family = (eax >> 20) & 0xff;
+            tty_printf("Extended family %d\n", extended_family);
+        }
+        tty_printf("Model %d - ", model);
+
+        switch (family) {
+        case 3:
+            break;
+        case 4:
+            switch (model) {
+            case 0:
+            case 1:
+                tty_printf("DX");
+                break;
+            case 2:
+                tty_printf("SX");
+                break;
+            case 3:
+                tty_printf("487/DX2");
+                break;
+            case 4:
+                tty_printf("SL");
+                break;
+            case 5:
+                tty_printf("SX2");
+                break;
+            case 7:
+                tty_printf("Write-back enhanced DX2");
+                break;
+            case 8:
+                tty_printf("DX4");
+                break;
+            }
+            break;
+        case 5:
+            switch (model) {
+            case 1:
+                tty_printf("60/66");
+                break;
+            case 2:
+                tty_printf("75-200");
+                break;
+            case 3:
+                tty_printf("for 486 system");
+                break;
+            case 4:
+                tty_printf("MMX");
+                break;
+            }
+            break;
+        case 6:
+            switch (model) {
+            case 1:
+                tty_printf("Pentium Pro");
+                break;
+            case 3:
+                tty_printf("Pentium II Model 3");
+                break;
+            case 5:
+                tty_printf("Pentium II Model 5/Xeon/Celeron");
+                break;
+            case 6:
+                tty_printf("Celeron");
+                break;
+            case 7:
+                tty_printf("Pentium III/Pentium III Xeon - external L2 cache");
+                break;
+            case 8:
+                tty_printf("Pentium III/Pentium III Xeon - internal L2 cache");
+                break;
+            }
+            break;
+        case 15:
+            break;
+        }
+
+        tty_printf("\n");
+    }
+    cpuid(0x80000000, max_eax, unused, unused, unused);
+
+    /* Quok said: If the max extended eax value is high enough to support the processor brand string
+    (values 0x80000002 to 0x80000004), then we'll use that information to return the brand information.
+    Otherwise, we'll refer back to the brand tables above for backwards compatibility with older processors.
+    According to the Sept. 2006 Intel Arch Software Developer's Guide, if extended eax values are supported,
+    then all 3 values for the processor brand string are supported, but we'll test just to make sure and be safe. */
+
+    if (max_eax >= 0x80000004) {
+        if (silent == 0){
+            tty_printf("Brand: ");
+            tty_printf("%s\n",brandAllName);
+        }
+        if (max_eax >= 0x80000002) {
+            cpuid(0x80000002, eax, ebx, ecx, edx);
+            (printregs(eax, ebx, ecx, edx));
+        }
+        if (max_eax >= 0x80000003) {
+            cpuid(0x80000003, eax, ebx, ecx, edx);
+            (printregs(eax, ebx, ecx, edx));
+        }
+        if (max_eax >= 0x80000004) {
+            cpuid(0x80000004, eax, ebx, ecx, edx);
+            (printregs(eax, ebx, ecx, edx));
+        }
+        if (silent == 0){
+            tty_printf("\n");
+        }
+    } else if (brand > 0 && silent == 0) {
+        tty_printf("Brand %d - ", brand);
+        if (brand < 0x18) {
+            if (signature == 0x000006B1 || signature == 0x00000F13) {
+                tty_printf("%s\n", Intel_Other[brand]);
+            } else {
+                tty_printf("%s\n", Intel[brand]);
+            }
+        } else {
+            tty_printf("Reserved\n");
+        }
+    }
+    if (silent == 0){
+        tty_printf("Stepping: %d Reserved: %d\n", stepping, reserved);
+    }
+    return 0;
+}
+
+/* Print Registers */
+char* printregs(int eax, int ebx, int ecx, int edx) {
+    int j;
+    char string[17];
+    string[16] = '\0';
+    for (j = 0; j < 4; j++) {
+        string[j] = eax >> (8 * j);
+        string[j + 4] = ebx >> (8 * j);
+        string[j + 8] = ecx >> (8 * j);
+        string[j + 12] = edx >> (8 * j);
+    }
+    //tty_printf("%s",string);
+    strcat(brandAllName,string);
+    return string;
+}
+
+/* AMD-specific information */
+int do_amd(bool silent) {
+    if (silent == 0){
+        tty_printf("Detected AMD CPU. \nAMD-specific features:\n");
+    }
+    unsigned long extended, eax, ebx, ecx, edx, unused;
+    int family, model, stepping, reserved;
+    cpuid(1, eax, unused, unused, unused);
+
+    model = (eax >> 4) & 0xf;
+    family = (eax >> 8) & 0xf;
+    stepping = eax & 0xf;
+    reserved = eax >> 12;
+    if (silent == 0){
+        tty_printf("Family: %d Model: %d [", family, model);
+        switch (family) {
+        case 4:
+            tty_printf("486 Model %d", model);
+            break;
+        case 5:
+            switch (model) {
+            case 0:
+            case 1:
+            case 2:
+            case 3:
+            case 6:
+            case 7:
+                tty_printf("K6 Model %d", model);
+                break;
+            case 8:
+                tty_printf("K6-2 Model 8");
+                break;
+            case 9:
+                tty_printf("K6-III Model 9");
+                break;
+            default:
+                tty_printf("K5/K6 Model %d", model);
+                break;
+            }
+            break;
+        case 6:
+            switch (model) {
+            case 1:
+            case 2:
+            case 4:
+                tty_printf("Athlon Model %d", model);
+                break;
+            case 3:
+                tty_printf("Duron Model 3");
+                break;
+            case 6:
+                tty_printf("Athlon MP/Mobile Athlon Model 6");
+                break;
+            case 7:
+                tty_printf("Mobile Duron Model 7");
+                break;
+            default:
+                tty_printf("Duron/Athlon Model %d", model);
+                break;
+            }
+            break;
+        }
+
+        tty_printf("]\n");
+    }
+    cpuid(0x80000000, extended, unused, unused, unused);
+    if (extended == 0) {
+        return 0;
+    }
+    if (extended >= 0x80000002) {
+        unsigned int j;
+        if (silent == 0){
+            tty_printf("Detected Processor Name: ");
+        }
+        for (j = 0x80000002; j <= 0x80000004; j++) {
+            cpuid(j, eax, ebx, ecx, edx);
+            if (silent == 0){
+                tty_printf(printregs(eax, ebx, ecx, edx));
+            }
+        }
+        if (silent == 0){
+            tty_printf("\n");
+        }
+    }
+    if (extended >= 0x80000007) {
+        cpuid(0x80000007, unused, unused, unused, edx);
+        if (edx & 1 && silent == 0) {
+            tty_printf("Temperature Sensing Diode Detected!\n");
+        }
+    }
+    if (silent == 0){
+        tty_printf("Stepping: %d Reserved: %d\n", stepping, reserved);
+    }
+    return 0;
+}


### PR DESCRIPTION
* Добавлена функция void strtolower(char* as) -> string.c
* Добавлена функция void strtoupper(char* as)  -> string.c
* Добавлена функция uint64_t getInstalledRam() -> pmm.c
* Добавлена функция uint64_t getAvailableRam() -> pmm.c
* Добавлен файл cpuinfo.c
* Добавлена функция int detect_cpu(bool silent) -> при 1, название процессора запишисься в переменую, при 0 выведет всю информацию -> cpuinfo.c
* Добавлена функция char* getNameBrand() - Выводит полное название процессора -> cpuinfo.c
* Добавлены VendorID и DeviceID для VirtualBox Virtual Driver / QEMU Virtual Driver / VirtualBox Guest Additions Driver -> pci.c
* Изменино время возращения до 5 секунд -> tui.c
* Добавлена функция detect_cpu() для автоматического определения процессора -> kernel.c
* Добавлен иклуд cpuinfo.h -> kernel.h
* Добавлена команда cpuinfo в консольное приложение - для вывода подробной информации о процессоре -> shell.c